### PR TITLE
fix(vault): throw if custom passcode dismissed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2036,9 +2036,9 @@
       }
     },
     "@ionic-enterprise/identity-vault": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ionic-enterprise/identity-vault/-/identity-vault-4.2.0.tgz",
-      "integrity": "sha512-hMxRbLZBbBdu/65iigPpa6IozGPPBGCt0Y9nWhoUH4EY226RUbddLUkji9bqJGDYc5Z5Z5Zk7T2BntlHlJpkpA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.ionicframework.com/@ionic-enterprise%2fidentity-vault/-/identity-vault-4.2.1.tgz",
+      "integrity": "sha512-DBYel7RzzvwWKKfx8pU2v64xXl3pWuzCeGat+MUwuCmYzUrq/37UAEixaNr9E/M7qZosXjefdJdjso6ECR7nag==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@capacitor/core": "~2.1.0",
     "@capacitor/ios": "~2.1.0",
     "@ionic-enterprise/auth": "~2.1.0",
-    "@ionic-enterprise/identity-vault": "~4.2.0",
+    "@ionic-enterprise/identity-vault": "~4.2.1",
     "@ionic/angular": "~5.1.1",
     "@ionic/storage": "~2.2.0",
     "core-js": "~3.6.5",

--- a/src/app/login/login.page.ts
+++ b/src/app/login/login.page.ts
@@ -45,10 +45,12 @@ export class LoginPage {
     try {
       await this.vaultService.unlock();
     } catch (error) {
-      alert('Unable to unlock the token');
-      this.setUnlockType();
-      if (error.code !== VaultErrorCodes.AuthFailed) {
+      if (this.notFailedOrCancelled(error)) {
         throw error;
+      }
+      if (error.code === VaultErrorCodes.AuthFailed) {
+        alert('Unable to unlock the token');
+        this.setUnlockType();
       }
     }
   }
@@ -83,5 +85,9 @@ export class LoginPage {
     } else {
       this.loginType = '';
     }
+  }
+
+  private notFailedOrCancelled(error: any) {
+    return error.code !== VaultErrorCodes.AuthFailed && error.code !== VaultErrorCodes.UserCanceledInteraction;
   }
 }

--- a/src/app/services/vault/vault.service.ts
+++ b/src/app/services/vault/vault.service.ts
@@ -7,6 +7,7 @@ import { PinDialogComponent } from '@app/pin-dialog/pin-dialog.component';
 import { BrowserAuthPlugin } from '../browser-auth/browser-auth.plugin';
 import { SettingsService } from '../settings/settings.service';
 import { Subject, Observable } from 'rxjs';
+import { VaultErrorCodes } from 'plugins/@ionic-enterprise/identity-vault/dist/esm';
 
 @Injectable({
   providedIn: 'root'
@@ -74,8 +75,13 @@ export class VaultService extends IonicIdentityVaultUser<any> {
       }
     });
     dlg.present();
-    const { data } = await dlg.onDidDismiss();
-    return data || '';
+    const { data, role } = await dlg.onDidDismiss();
+    if (role === 'cancel')
+      throw {
+        code: VaultErrorCodes.UserCanceledInteraction,
+        message: 'User has canceled supplying the application passcode'
+      };
+    return Promise.resolve(data || '');
   }
 
   onVaultUnlocked() {


### PR DESCRIPTION
# What this PR includes:
This Pull Request suppresses the application from requesting the Vault to unlock at the native layer when the user cancels out of the custom passcode modal.

## Issues Resolved
* #4 Throw VaultError on Application PIN cancel when unlocking

## Additional Changes
* Suppress _"Unable to unlock the token"_ alert unless the the error code equals `VaultErrorCodes.AuthFailed`.
* Update `@ionic-enterprise/identity-vault` to `~4.2.1`.